### PR TITLE
feat: add settings/options page with tracked video management

### DIFF
--- a/src/entrypoints/options/App.css
+++ b/src/entrypoints/options/App.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/src/entrypoints/options/App.tsx
+++ b/src/entrypoints/options/App.tsx
@@ -1,0 +1,104 @@
+import { useMemo } from 'react'
+import { videoStorage, videoStorageItem } from '../../storage/videoStorage'
+import { formatTime, timeAgo } from '../../utils'
+import { useVideoStorage } from '../popup/useVideoStorage'
+
+function getThumbnail(id: string) {
+  return `https://i.ytimg.com/vi/${id}/mqdefault.jpg`
+}
+
+const FALLBACK_VIDEO_DURATION = 4 * 60 * 60
+
+export default function App() {
+  const videos = useVideoStorage()
+  const sortedVideos = useMemo(
+    () => (videos ? Object.values(videos).sort((a, b) => b.timestamp - a.timestamp) : null),
+    [videos],
+  )
+
+  async function clearAll() {
+    await videoStorageItem.setValue({})
+  }
+
+  if (!sortedVideos) return null
+
+  return (
+    <div className="mx-auto max-w-4xl p-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-xl font-semibold text-gray-900">Tracked Videos</h1>
+        {sortedVideos.length > 0 && (
+          <button
+            onClick={clearAll}
+            className="rounded-md bg-red-50 px-3 py-1.5 text-sm font-medium text-red-600 transition-colors hover:bg-red-100"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {sortedVideos.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 py-20">
+          <svg className="text-gray-300" width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z" />
+          </svg>
+          <p className="text-sm text-gray-400">No videos tracked yet</p>
+          <p className="text-xs text-gray-300">Watch a YouTube video to get started</p>
+        </div>
+      ) : (
+        <div className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
+          {sortedVideos.map(({ id, progress, duration, timestamp, title, url }) => {
+            const progressPercent = Math.min((progress / (duration ?? FALLBACK_VIDEO_DURATION)) * 100, 100)
+            return (
+              <div key={id} className="group flex items-center gap-4 p-4 transition-colors hover:bg-gray-50">
+                {/* Thumbnail */}
+                <a href={url} target="_blank" rel="noreferrer" className="relative shrink-0">
+                  <img
+                    src={getThumbnail(id)}
+                    alt={title}
+                    className="h-[63px] w-[112px] rounded object-cover"
+                  />
+                  <span className="absolute right-1 bottom-1 rounded bg-black/80 px-1 py-0.5 text-[10px] font-medium text-white">
+                    {formatTime(progress)}
+                  </span>
+                </a>
+
+                {/* Info */}
+                <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="line-clamp-1 text-sm font-medium text-gray-900 hover:text-blue-600"
+                  >
+                    {title}
+                  </a>
+                  <div className="h-1 w-full overflow-hidden rounded-full bg-gray-200">
+                    <div
+                      className="h-full rounded-full bg-red-500 transition-all"
+                      style={{ width: `${progressPercent}%` }}
+                    />
+                  </div>
+                  <span className="text-xs text-gray-400">{timeAgo(timestamp)}</span>
+                </div>
+
+                {/* Delete */}
+                <button
+                  onClick={() => videoStorage.remove(id)}
+                  className="rounded p-1.5 text-gray-400 opacity-0 transition-opacity hover:text-red-500 group-hover:opacity-100"
+                  title="Remove"
+                >
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <polyline points="3 6 5 6 21 6" />
+                    <path d="M19 6l-1 14H6L5 6" />
+                    <path d="M10 11v6M14 11v6" />
+                    <path d="M9 6V4h6v2" />
+                  </svg>
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>YouTube Tracker — Settings</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -1,0 +1,6 @@
+import './App.css'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+const root = document.getElementById('root')!
+createRoot(root).render(<App />)

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -1,28 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { trackingEnabledItem, videoStorage } from '../../storage/videoStorage'
+import { formatTime, timeAgo } from '../../utils'
 import { useVideoStorage } from './useVideoStorage'
-
-function formatTime(seconds: number) {
-  const h = Math.floor(seconds / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  const s = Math.floor(seconds % 60)
-  return [h, m, s]
-    .map((v) => (v < 10 ? '0' + v : v))
-    .filter((v, i) => v !== '00' || i > 0)
-    .join(':')
-    .replace(/^0/, '')
-}
-
-function timeAgo(timestamp: number) {
-  const diff = Date.now() - timestamp
-  const minutes = Math.floor(diff / 60000)
-  if (minutes < 1) return 'just now'
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
-}
 
 function getThumbnail(id: string) {
   return `https://i.ytimg.com/vi/${id}/mqdefault.jpg`
@@ -61,6 +40,16 @@ export default function App() {
           <span className={`inline-block h-3 w-3 rounded-full bg-white shadow transition-transform ${trackingEnabled ? 'translate-x-3.5' : 'translate-x-0.5'}`} />
         </span>
         {trackingEnabled ? 'Tracking' : 'Paused'}
+      </button>
+      <button
+        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/options.html') })}
+        className="rounded p-1 text-gray-400 transition-colors hover:text-gray-600"
+        title="Settings"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </svg>
       </button>
     </div>
   )

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { formatTime, timeAgo } from './utils'
+
+describe('formatTime', () => {
+  it('formats seconds below a minute', () => {
+    expect(formatTime(0)).toBe('0:00')
+    expect(formatTime(30)).toBe('0:30')
+    expect(formatTime(59)).toBe('0:59')
+  })
+
+  it('formats minutes and seconds', () => {
+    expect(formatTime(60)).toBe('1:00')
+    expect(formatTime(65)).toBe('1:05')
+    expect(formatTime(90)).toBe('1:30')
+    expect(formatTime(599)).toBe('9:59')
+  })
+
+  it('pads seconds with leading zero', () => {
+    expect(formatTime(61)).toBe('1:01')
+    expect(formatTime(3601)).toBe('1:00:01')
+  })
+
+  it('formats hours, minutes, and seconds', () => {
+    expect(formatTime(3600)).toBe('1:00:00')
+    expect(formatTime(3661)).toBe('1:01:01')
+    expect(formatTime(5400)).toBe('1:30:00')
+    expect(formatTime(7199)).toBe('1:59:59')
+  })
+
+  it('omits hours when zero', () => {
+    expect(formatTime(3599)).toBe('59:59')
+  })
+})
+
+describe('timeAgo', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-01T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const now = new Date('2024-01-01T12:00:00Z').getTime()
+
+  it('returns "just now" for less than a minute ago', () => {
+    expect(timeAgo(now)).toBe('just now')
+    expect(timeAgo(now - 59_000)).toBe('just now')
+  })
+
+  it('returns minutes for less than an hour ago', () => {
+    expect(timeAgo(now - 60_000)).toBe('1m ago')
+    expect(timeAgo(now - 5 * 60_000)).toBe('5m ago')
+    expect(timeAgo(now - 59 * 60_000)).toBe('59m ago')
+  })
+
+  it('returns hours for less than a day ago', () => {
+    expect(timeAgo(now - 60 * 60_000)).toBe('1h ago')
+    expect(timeAgo(now - 3 * 60 * 60_000)).toBe('3h ago')
+    expect(timeAgo(now - 23 * 60 * 60_000)).toBe('23h ago')
+  })
+
+  it('returns days for a day or more ago', () => {
+    expect(timeAgo(now - 24 * 60 * 60_000)).toBe('1d ago')
+    expect(timeAgo(now - 7 * 24 * 60 * 60_000)).toBe('7d ago')
+  })
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,21 @@
+export function formatTime(seconds: number) {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = Math.floor(seconds % 60)
+  return [h, m, s]
+    .map((v) => (v < 10 ? '0' + v : v))
+    .filter((v, i) => v !== '00' || i > 0)
+    .join(':')
+    .replace(/^0/, '')
+}
+
+export function timeAgo(timestamp: number) {
+  const diff = Date.now() - timestamp
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}


### PR DESCRIPTION
## Summary

- Adds a full-screen options page (`src/entrypoints/options/`) registered automatically by WXT
- Options page lists all tracked videos with thumbnail, progress bar, per-row delete button, and a "Clear all" button
- Extracts `formatTime`/`timeAgo` into a shared `src/utils.ts` so both the popup and options page reuse the same logic
- Adds a gear icon button in the popup header that opens the options page in a new tab

Closes #2

## Test plan

- [ ] Load the unpacked extension in Chrome/Brave
- [ ] Watch a YouTube video so at least one entry is tracked
- [ ] Click the gear icon in the popup — options page should open in a new tab
- [ ] Verify all tracked videos appear with thumbnail, title, progress bar, and timestamp
- [ ] Delete a single video via the trash icon (hover to reveal)
- [ ] Use "Clear all" to wipe all tracked data
- [ ] Confirm `npm run test`, `npm run type-check`, `npm run lint`, and `npm run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)